### PR TITLE
Commands entered using ':' run as a Weechat command after checked against list

### DIFF
--- a/vimode.py
+++ b/vimode.py
@@ -779,7 +779,7 @@ def cb_exec_cmd(data, remaining_calls):
         if cmd in VI_COMMANDS:
             weechat.command('', "%s %s" % (VI_COMMANDS[cmd], args))
         else:
-            weechat.prnt('', "Command '%s' not found." % cmd)
+            weechat.command('', "/{} {}".format(cmd, args))
     return weechat.WEECHAT_RC_OK
 
 


### PR DESCRIPTION
When a command is entered using ':', after testing the command against the command list, it is passed through as a command to Weechat. Allows ':' to be the interface for all Weechat commands. If a command is unknown to weechat it will still print 'unknown command' in the main buffer.  Example: ':join #freenode' runs as '/join freenode'

I personally found this to really extend vimode in my own work - though I don't know what route you see this project going long term.  
