### PR TITLE
Add buffer commands to navigate buffers

### DIFF
--- a/vimode.py
+++ b/vimode.py
@@ -104,6 +104,11 @@ VI_COMMANDS = {'h': "/help",
                'q': "/close",
                'w': "/save",
                'set': "/set",
+               'bp': "/buffer -1",
+               'bn': "/buffer +1",
+               'bd': "/close",
+               'b#': "/input jump_last_buffer",
+               'b': "/buffer",
                'sp': "/window splith",
                'vsp': "/window splitv"}
 


### PR DESCRIPTION
I added a few commands to match vim's buffer handling, such that you can navigate through buffers and close them using `bp`, `bd`, `bn`, `b#` and `b [n]`.
