### PR TITLE
Support vi commands without blank before data

### DIFF
--- a/vimode.py
+++ b/vimode.py
@@ -1124,6 +1124,7 @@ def cb_exec_cmd(data, remaining_calls):
         weechat.command("", "/cursor go {},{}".format(x, y))
     # Check againt defined commands.
     else:
+        raw_data = data
         data = data.split(" ", 1)
         cmd = data[0]
         args = ""
@@ -1131,8 +1132,18 @@ def cb_exec_cmd(data, remaining_calls):
             args = data[1]
         if cmd in VI_COMMANDS:
             weechat.command("", "%s %s" % (VI_COMMANDS[cmd], args))
-        # No vi commands defined, run the command as a WeeChat command.
         else:
+            # Check for cmds not sepearated by space (ie b2)
+            i = 1
+            while i < len(raw_data):
+                cmd = raw_data[:i]
+                args = raw_data[i:]
+                if cmd in VI_COMMANDS:
+                    weechat.command('', "%s %s" % (VI_COMMANDS[cmd], args))
+                    return weechat.WEECHAT_RC_OK
+                i = i+1
+
+            # No vi commands found, run the command as WeeChat command
             weechat.command("", "/{} {}".format(cmd, args))
     return weechat.WEECHAT_RC_OK
 


### PR DESCRIPTION
To allow buffer changes with "bX" instead of "b X" parse the input char-wise
if space based splitting is not successfull.

Signed-off-by: Julian Scheel <julian@jusst.de>