### PR TITLE
Fix first symbolic link example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ follows:
 
     cd ~/.weechat/python/
     wget 'https://github.com/GermainZ/weechat-vimode/raw/master/vimode.py'
-    ln -s ../vimode.py autoload/vimode.py
+    cd autoload/
+    ln -s ../vimode.py .
 
 If you prefer to clone the git repo (allowing you to easily update it), you can
 do the following instead:


### PR DESCRIPTION
Just a quick fix of the example in the readme, should be apparent.