### PR TITLE
Mod: improved already existing :nmap command

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ count. This will all probably be easier to grasp after seeing a few examples:
      - OUTPUT [j]: Go three buffers down.
      - OUTPUT [3j]: Go nine buffers down.
 
-5) Special "count tag" gives you more flexibility when using counts:
+5) Special "count tag" gives you more flexibility when using external counts:
      - INPUT: `:nmap @ /buffer #{3}<CR>`
      - OUTPUT [7@]: Go to the seventh buffer.
      - OUTPUT [@]: Go to the third buffer.

--- a/README.md
+++ b/README.md
@@ -237,25 +237,25 @@ count. This will all probably be easier to grasp after seeing a few examples:
 
 1) Commands can be bound together easily:
      - INPUT: `:nmap h /cmd1<CR>/cmd2<CR>`
-     - OUTPUT **[h]**: Runs `/cmd1` then `/cmd2`.
+     - OUTPUT [h]: Runs `/cmd1` then `/cmd2`.
 
 2) User defined bindings can be followed:
      - INPUT: `:nmap j /buffer 5<CR>h`
-     - OUTPUT **[j]**: Go to the fifth buffer, then run `/cmd1`, and then run `/cmd2`.
+     - OUTPUT [j]: Go to the fifth buffer, then run `/cmd1`, and then run `/cmd2`.
 
 3) Bindings can take advantage of INSERT mode:
      - INPUT: `:nmap k i MESSAGE<Esc>0i`
-     - OUTPUT **[k]**: Prints ' MESSAGE' to command-line and then returns the user to the beginning of the line. The user is left in INSERT mode.
+     - OUTPUT [k]: Prints ' MESSAGE' to command-line and then returns the user to the beginning of the line. The user is left in INSERT mode.
 
 4) Counts are respected both internally and externally:
      - INPUT: `:nmap j 3J`
-     - OUTPUT **[j]**: Go three buffers down.
-     - OUTPUT **[3j]**: Go nine buffers down.
+     - OUTPUT [j]: Go three buffers down.
+     - OUTPUT [3j]: Go nine buffers down.
 
 5) Special "count tag" gives you more flexibility:
      - INPUT: `:nmap @ /buffer #{3}<CR>`
-     - OUTPUT **[7@]**: Go to the seventh buffer.
-     - OUTPUT **[@]**: Go to the third buffer.
+     - OUTPUT [7@]: Go to the seventh buffer.
+     - OUTPUT [@]: Go to the third buffer.
 
 # History:
 * version 0.1:      initial release

--- a/README.md
+++ b/README.md
@@ -237,25 +237,25 @@ count. This will all probably be easier to grasp after seeing a few examples:
 
 1) Commands can be bound together easily:
      - INPUT: `:nmap h /cmd1<CR>/cmd2<CR>`
-     - OUTPUT [h]: Runs `/cmd1` then `/cmd2`.
+     - OUTPUT **[h]**: Runs `/cmd1` then `/cmd2`.
 
 2) User defined bindings can be followed:
      - INPUT: `:nmap j /buffer 5<CR>h`
-     - OUTPUT [j]: Go to the fifth buffer, then run `/cmd1`, and then run `/cmd2`.
+     - OUTPUT **[j]**: Go to the fifth buffer, then run `/cmd1`, and then run `/cmd2`.
 
 3) Bindings can take advantage of INSERT mode:
      - INPUT: `:nmap k i MESSAGE<Esc>0i`
-     - OUTPUT [k]: Prints ' MESSAGE' to command-line and then returns the user to the beginning of the line. The user is left in INSERT mode.
+     - OUTPUT **[k]**: Prints ' MESSAGE' to command-line and then returns the user to the beginning of the line. The user is left in INSERT mode.
 
 4) Counts are respected both internally and externally:
      - INPUT: `:nmap j 3J`
-     - OUTPUT [j]: Go three buffers down.
-     - OUTPUT [3j]: Go nine buffers down.
+     - OUTPUT **[j]**: Go three buffers down.
+     - OUTPUT **[3j]**: Go nine buffers down.
 
 5) Special "count tag" gives you more flexibility:
      - INPUT: `:nmap @ /buffer #{3}<CR>`
-     - OUTPUT [7@]: Go to the seventh buffer.
-     - OUTPUT [@]: Go to the third buffer.
+     - OUTPUT **[7@]**: Go to the seventh buffer.
+     - OUTPUT **[@]**: Go to the third buffer.
 
 # History:
 * version 0.1:      initial release

--- a/README.md
+++ b/README.md
@@ -218,9 +218,9 @@ information). `&` in the replacement is also substituted by the pattern. If the
 User mappings are created using `:nmap {lhs} {rhs}`. The `{rhs}` argument consists of any
 combination of the following:
 
-* A WeeChat command specified with: `/command [options]<CR>`. You may also use a colon (`:`)
+* A WeeChat command, specified with: `/command [options]<CR>`. You may also use a colon (`:`)
   in place of the forward slash (`/`) if you wish.
-* An INSERT mode action can be specified by an `A`, `I`, `i`, or `a` to enter INSERT mode; then an
+* An INSERT mode action, specified by an `A`, `I`, `i`, or `a` to enter INSERT mode; then an
   (optional) arbitrary string of characters to send to the command-line; and then (optionally) ending the
   pattern with a `<CR>` (to submit the text to the current buffer) or a `<Esc>` to end the INSERT
   mode action and go back to NORMAL mode.
@@ -229,30 +229,30 @@ combination of the following:
 
 A count may be specified either in the mapping itself or before triggering the mapping.
 Furthermore, you may place the following count tag anywhere (except inside an INSERT action) within
-the binding (`{rhs}`): `#{N}`, where `N` is some arbitrary integer. This special tag is used to
-"consume" an external count. If no external count is provided, `N` will be used as the default
+the binding (`{rhs}`): `#{N}`, where `N` is some arbitrary integer. This special "count tag" is used to
+consume an external count. If no external count is provided, `N` will be used as the default
 count. This will all probably be easier to grasp after seeing a few examples:
 
 ### Examples
 
-1) Commands can be bound together easily:
+1) Commands can be concatenated together:
      - INPUT: `:nmap h /cmd1<CR>/cmd2<CR>`
      - OUTPUT [h]: Runs `/cmd1` then `/cmd2`.
 
-2) User defined bindings can be followed:
+2) User defined bindings will be followed:
      - INPUT: `:nmap j /buffer 5<CR>h`
      - OUTPUT [j]: Go to the fifth buffer, then run `/cmd1`, and then run `/cmd2`.
 
 3) Bindings can take advantage of INSERT mode:
-     - INPUT: `:nmap k i MESSAGE<Esc>0i`
-     - OUTPUT [k]: Prints ' MESSAGE' to command-line and then returns the user to the beginning of the line. The user is left in INSERT mode.
+     - INPUT: `:nmap k i/msg <Esc>0i`
+     - OUTPUT [k]: Prints "/msg " to the command-line and then returns the user to the beginning of the line. The user is left in INSERT mode.
 
 4) Counts are respected both internally and externally:
      - INPUT: `:nmap j 3J`
      - OUTPUT [j]: Go three buffers down.
      - OUTPUT [3j]: Go nine buffers down.
 
-5) Special "count tag" gives you more flexibility:
+5) Special "count tag" gives you more flexibility when using counts:
      - INPUT: `:nmap @ /buffer #{3}<CR>`
      - OUTPUT [7@]: Go to the seventh buffer.
      - OUTPUT [@]: Go to the third buffer.

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Normal mode. When in search mode, pressing `/` will start a new search.
                     Close the current buffer (`/close`).
 * `:b#`             Go to the last buffer (`/input jump_last_buffer`).
 * `:b [N]`, `:bu [N]`, `:buf [N]`, `:buffer [N]`
-                    Go to buffer [N].
+                    Go to buffer `[N]`.
 * `:sp`, `:split`   Split current window in two (`/window splith`).
 * `:vs`, `:vsplit`  Split current window in two, but vertically
                     (`/window splitv`).
@@ -202,16 +202,11 @@ Normal mode. When in search mode, pressing `/` will start a new search.
 * `:<num>`          Start cursor mode and go to line.
 * `:nmap`           List user-defined key mappings.
 * `:nmap {lhs} {rhs}`
-                    Map {lhs} to {rhs} for Normal mode.
-                    Some (but not all) vim-like key codes are supported: <Up>,
-                    <Down>, <Left>, <Right>, <C-...> and <M-...>.
-                    User-defined mappings are not followed (e.g. doing `:nmap z
-                    j` followed by `:nmap u z` will result in `u` not doing
-                    anything, since `z` is a user-defined mapping).
-                    Default vimode bindings can be used (e.g. `:nmap J K`
-                    followed by `:nmap K J` will flip `J` and `K` without
-                    resulting in a loop).
-* `:nunmap {lhs}`   Remove the mapping of {lhs} for Normal mode.
+                    Map `{lhs}` to `{rhs}` for Normal mode.  Some (but not all) vim-like key codes are
+                    supported: `<Up>`, `<Down>`, `<Left>`, `<Right>`, `<C-...>` and `<M-...>`. These "user
+                    mappings" share much of the flexibility you are accustomed to from using regular
+                    vim mappings. See the [User Mappings](#usermaps) section for details and examples.
+* `:nunmap {lhs}`   Remove the mapping of `{lhs}` for Normal mode.
 * `:command`        All other commands will be passed to WeeChat (e.g.
                     ":script …" is equivalent to "/script …").
 
@@ -219,6 +214,48 @@ Normal mode. When in search mode, pressing `/` will start a new search.
 information). `&` in the replacement is also substituted by the pattern. If the
 `g` flag isn't present, only the first match will be substituted.
 
+# <a name="usermaps"></a>User Mappings
+User mappings are created using `:nmap {lhs} {rhs}`. The `{rhs}` argument consists of any
+combination of the following:
+
+* A WeeChat command specified with: `/command [options]<CR>`. You may also use a colon (`:`)
+  in place of the forward slash (`/`) if you wish.
+* An INSERT mode action can be specified by an `A`, `I`, `i`, or `a` to enter INSERT mode; then an
+  (optional) arbitrary string of characters to send to the command-line; and then (optionally) ending the
+  pattern with a `<CR>` (to submit the text to the current buffer) or a `<Esc>` to end the INSERT
+  mode action and go back to NORMAL mode.
+* Keys specifying a vim motion (`h`,`j`,`k`,`l`,`^`,`0`, etc.).
+* Keys specifying a vim operation (`dd`, `y$`, `cw`, etc.).
+
+A count may be specified either in the mapping itself or before triggering the mapping.
+Furthermore, you may place the following count tag anywhere (except inside an INSERT action) within
+the binding (`{rhs}`): `#{N}`, where `N` is some arbitrary integer. This special tag is used to
+"consume" an external count. If no external count is provided, `N` will be used as the default
+count. This will all probably be easier to grasp after seeing a few examples:
+
+### Examples
+
+1) Commands can be bound together easily:
+     - INPUT: `:nmap h /cmd1<CR>/cmd2<CR>`
+     - OUTPUT [h]: Runs `/cmd1` then `/cmd2`.
+
+2) User defined bindings can be followed:
+     - INPUT: `:nmap j /buffer 5<CR>h`
+     - OUTPUT [j]: Go to the fifth buffer, then run `/cmd1`, and then run `/cmd2`.
+
+3) Bindings can take advantage of INSERT mode:
+     - INPUT: `:nmap k i MESSAGE<Esc>0i`
+     - OUTPUT [k]: Prints ' MESSAGE' to command-line and then returns the user to the beginning of the line. The user is left in INSERT mode.
+
+4) Counts are respected both internally and externally:
+     - INPUT: `:nmap j 3J`
+     - OUTPUT [j]: Go three buffers down.
+     - OUTPUT [3j]: Go nine buffers down.
+
+5) Special "count tag" gives you more flexibility:
+     - INPUT: `:nmap @ /buffer #{3}<CR>`
+     - OUTPUT [7@]: Go to the seventh buffer.
+     - OUTPUT [@]: Go to the third buffer.
 
 # History:
 * version 0.1:      initial release

--- a/vimode.py
+++ b/vimode.py
@@ -197,6 +197,7 @@ def cmd_nmap(args):
         if mappings:
             title = "----- Vimode User Mappings -----"
             bar = '-' * len(title)
+
             weechat.prnt("", bar)
             weechat.prnt("", title)
             weechat.prnt("", bar)
@@ -207,7 +208,12 @@ def cmd_nmap(args):
                                     (r'\u0001\[([A-Z])', r'<M-\1>')]:
                     pretty_keys = re.sub(pttrn, repl, pretty_keys)
 
-                weechat.prnt("", '("{}", "{}")'.format(pretty_keys, mapping))
+                pretty_mapping = mapping
+                for pttrn, repl in [('"', '\\"')]:
+                    pretty_mapping = re.sub(pttrn, repl, pretty_mapping)
+
+                msg_fmt = '("{}", "{}")'
+                weechat.prnt("", msg_fmt.format(pretty_keys, pretty_mapping))
         else:
             weechat.prnt("", "nmap: no mapping found.")
     elif " " not in args:

--- a/vimode.py
+++ b/vimode.py
@@ -1085,11 +1085,13 @@ class UserMapping:
             yield from self.get_cmd_actions(cmd[end:], first_call=first_call)
             return
 
+        lcmd = cmd.lower()
+
         command_pttrn = '[:/].*?<cr>'
         old_style_cmd_conditions = [
             first_call,
             cmd[0] == '/',
-            re.match(command_pttrn, cmd) is None,
+            re.match(command_pttrn, lcmd) is None,
         ]
 
         if all(old_style_cmd_conditions):
@@ -1098,7 +1100,6 @@ class UserMapping:
 
         debug_print('cmd', cmd)
 
-        lcmd = cmd.lower()
         if lcmd.startswith('<cr>'):
             yield self.command_to_action('/input return')
             yield from self.get_cmd_actions(cmd[4:])

--- a/vimode.py
+++ b/vimode.py
@@ -1051,7 +1051,7 @@ class UserMapping:
     """
     def __init__(self, cmd):
         self.cmd = cmd
-        self.count = 1
+        self.count = 0
 
     def __call__(self, buf, input_line, cur, count):
         for _ in range(max(count, 1)):
@@ -1064,7 +1064,7 @@ class UserMapping:
 
                 action(buf, input_line, cur, self.count)
 
-                self.count = 1
+                self.count = 0
                 buf = weechat.current_buffer()
                 input_line = weechat.buffer_get_string(buf, "input")
                 cur = weechat.buffer_get_integer(buf, "input_pos")
@@ -1078,9 +1078,11 @@ class UserMapping:
         if cmd == '':
             return
 
-        if re.match('^[1-9]', cmd):
-            self.count += int(cmd[0])
-            yield from self.get_cmd_actions(cmd[1:])
+        match = re.match('^[1-9][0-9]*', cmd)
+        if match:
+            end = match.end()
+            self.count += int(cmd[:end])
+            yield from self.get_cmd_actions(cmd[end:], first_call=first_call)
             return
 
         command_pttrn = '[:/].*<cr>'

--- a/vimode.py
+++ b/vimode.py
@@ -1050,7 +1050,8 @@ class UserMapping:
 
     Enables multiple actions to be defined by a single mapping.
     """
-    def __init__(self, cmd):
+    def __init__(self, keys, cmd):
+        self.keys = keys
         self.cmd = cmd
         self.count = 0
         self.bad_sequence = ""
@@ -1083,7 +1084,8 @@ class UserMapping:
 
             for bad_seq in bad_sequence_list:
                 error_msg = 'Failed to parse "{}" sequence ' \
-                            'in nmap binding.'.format(bad_seq)
+                    'in the following user mapping: ' \
+                    '({}, {}).'.format(bad_seq, self.keys, self.cmd)
                 print_warning(error_msg)
 
     def get_cmd_actions(self, cmd, *, first_call=False):
@@ -1592,7 +1594,7 @@ def load_user_mappings():
         mappings.update(json.loads(vimode_settings['user_mappings']))
     vimode_settings['user_mappings'] = mappings
     for k, v in mappings.items():
-        VI_KEYS[k] = UserMapping(v)
+        VI_KEYS[k] = UserMapping(k, v)
 
 
 # Command-line execution.

--- a/vimode.py
+++ b/vimode.py
@@ -1054,9 +1054,16 @@ class UserMapping:
         self.bad_sequence = ""
 
     def __call__(self, buf, input_line, cur, count):
-        for _ in range(max(count, 1)):
+        if '#N' in self.full_cmd:
+            full_cmd = self.full_cmd.replace('#N', str(count))
+            count = 1
+        else:
+            full_cmd = self.full_cmd
+            count = max(count, 1)
+
+        for _ in range(count):
             bad_sequence_list = []
-            for action in self.get_cmd_actions(self.full_cmd, first_call=True):
+            for action in self.get_cmd_actions(full_cmd, first_call=True):
                 debug_print('action', action)
                 debug_print('buf', buf)
                 debug_print('input_line', input_line)
@@ -1838,7 +1845,6 @@ def get_keys_and_count(combo):
             we should handle. User mappings are also expanded.
         count (int): count for `combo`.
     """
-
     # Look for a potential match (e.g. "d" might become "dw" or "dd" so we
     # accept it, but "d9" is invalid).
     matched = False

--- a/vimode.py
+++ b/vimode.py
@@ -1054,19 +1054,20 @@ class UserMap:
         self.count = 1
 
     def __call__(self, buf, input_line, cur, count):
-        for action in self.get_cmd_actions(self.cmd, first_call=True):
-            debug_print('action', action)
-            debug_print('buf', buf)
-            debug_print('input_line', input_line)
-            debug_print('cur', cur)
-            debug_print('count', count)
+        for _ in range(max(count, 1)):
+            for action in self.get_cmd_actions(self.cmd, first_call=True):
+                debug_print('action', action)
+                debug_print('buf', buf)
+                debug_print('input_line', input_line)
+                debug_print('cur', cur)
+                debug_print('count', count)
 
-            action(buf, input_line, cur, self.count)
+                action(buf, input_line, cur, self.count)
 
-            self.count = 1
-            buf = weechat.current_buffer()
-            input_line = weechat.buffer_get_string(buf, "input")
-            cur = weechat.buffer_get_integer(buf, "input_pos")
+                self.count = 1
+                buf = weechat.current_buffer()
+                input_line = weechat.buffer_get_string(buf, "input")
+                cur = weechat.buffer_get_integer(buf, "input_pos")
 
     def get_cmd_actions(self, cmd, *, first_call=False):
         """Returns List of Callable Actions"""

--- a/vimode.py
+++ b/vimode.py
@@ -208,6 +208,10 @@ def cmd_nmap(args):
                 pretty_keys = keys
                 for pttrn, repl in [(r'\u0001([A-Z])', r'<C-\1>'),
                                     (r'\u0001\[([A-Z])', r'<M-\1>'),
+                                    (r'\u0001\[\[A', r'<Up>'),
+                                    (r'\u0001\[\[B', r'<Down>'),
+                                    (r'\u0001\[\[C', r'<Right>'),
+                                    (r'\u0001\[\[D', r'<Left>'),
                                     ('"', '\\"')]:
                     pretty_keys = re.sub(pttrn, repl, pretty_keys)
 

--- a/vimode.py
+++ b/vimode.py
@@ -1085,7 +1085,7 @@ class UserMapping:
             yield from self.get_cmd_actions(cmd[end:], first_call=first_call)
             return
 
-        command_pttrn = '[:/].*<cr>'
+        command_pttrn = '[:/].*?<cr>'
         old_style_cmd_conditions = [
             first_call,
             cmd[0] == '/',

--- a/vimode.py
+++ b/vimode.py
@@ -1054,8 +1054,11 @@ class UserMapping:
         self.bad_sequence = ""
 
     def __call__(self, buf, input_line, cur, count):
-        if '#N' in self.full_cmd:
-            full_cmd = self.full_cmd.replace('#N', str(count))
+        if re.search('#{\d+}', self.full_cmd) is not None:
+            if count:
+                full_cmd = re.sub('#{\d+}', str(count), self.full_cmd)
+            else:
+                full_cmd = re.sub('#{(\d+)}', r'\1', self.full_cmd)
             count = 1
         else:
             full_cmd = self.full_cmd

--- a/vimode.py
+++ b/vimode.py
@@ -195,9 +195,19 @@ def cmd_nmap(args):
     if not args:
         mappings = vimode_settings['user_mappings']
         if mappings:
-            weechat.prnt("", "User-defined key mappings:")
-            for key, mapping in mappings.items():
-                weechat.prnt("", "{} -> {}".format(key, mapping))
+            title = "----- Vimode User Mappings -----"
+            bar = '-' * len(title)
+            weechat.prnt("", bar)
+            weechat.prnt("", title)
+            weechat.prnt("", bar)
+            for keys, mapping in sorted(mappings.items(),
+                                        key=lambda x: x[0].lower()):
+                pretty_keys = keys
+                for pttrn, repl in [(r'\u0001([A-Z])', r'<C-\1>'),
+                                    (r'\u0001\[([A-Z])', r'<M-\1>')]:
+                    pretty_keys = re.sub(pttrn, repl, pretty_keys)
+
+                weechat.prnt("", '("{}", "{}")'.format(pretty_keys, mapping))
         else:
             weechat.prnt("", "nmap: no mapping found.")
     elif " " not in args:

--- a/vimode.py
+++ b/vimode.py
@@ -1082,7 +1082,7 @@ class UserMapping:
         if match:
             end = match.end()
             self.count += int(cmd[:end])
-            yield from self.get_cmd_actions(cmd[end:], first_call=first_call)
+            yield from self.get_cmd_actions(cmd[end:])
             return
 
         lcmd = cmd.lower()

--- a/vimode.py
+++ b/vimode.py
@@ -205,7 +205,8 @@ def cmd_nmap(args):
                                         key=lambda x: x[0].lower()):
                 pretty_keys = keys
                 for pttrn, repl in [(r'\u0001([A-Z])', r'<C-\1>'),
-                                    (r'\u0001\[([A-Z])', r'<M-\1>')]:
+                                    (r'\u0001\[([A-Z])', r'<M-\1>'),
+                                    ('"', '\\"')]:
                     pretty_keys = re.sub(pttrn, repl, pretty_keys)
 
                 pretty_mapping = mapping
@@ -1083,12 +1084,6 @@ class UserMapping:
         for _ in range(count):
             bad_sequence_list = []
             for action in self.get_cmd_actions(full_cmd, first_call=True):
-                debug_print('action', action)
-                debug_print('buf', buf)
-                debug_print('input_line', input_line)
-                debug_print('cur', cur)
-                debug_print('count', count)
-
                 if self.bad_sequence:
                     bad_sequence_list.append(self.bad_sequence)
 
@@ -1140,8 +1135,6 @@ class UserMapping:
             yield functools.partial(do_command, cmd)
             return
 
-        debug_print('cmd', cmd)
-
         if lcmd.startswith('<cr>'):
             yield functools.partial(do_command, '/input return')
             yield from self.get_cmd_actions(cmd[4:])
@@ -1167,14 +1160,10 @@ class UserMapping:
 
         for keys, command in VI_KEYS.items():
             if cmd.startswith(keys):
-                debug_print('keys', keys)
-                debug_print('command', command)
-
                 if isinstance(command, str):
                     yield functools.partial(do_command, command)
                 else:
                     yield command
-                debug_print('cmd[len(keys)', cmd[len(keys):])
                 yield from self.get_cmd_actions(cmd[len(keys):])
                 return
 
@@ -1199,7 +1188,6 @@ class UserMapping:
             return
 
         if cmd[0] in (':', '/'):
-            debug_print('/command [options]', cmd)
             self.bad_sequence += cmd
             return
 
@@ -1928,15 +1916,6 @@ def get_keys_and_count(combo):
 
 # Other helpers.
 # --------------
-def debug_print(name, value):
-    """Prints the Name and Value of a Variable
-
-    Toggle the DEBUGGING_ENABLED to enable/disable debug output.
-    """
-    DEBUGGING_ENABLED = False
-    if DEBUGGING_ENABLED:
-        print('[DEBUG] {} = {}'.format(name, value))
-
 def set_mode(arg):
     """Set the current mode and update the bar mode indicator."""
     global mode

--- a/vimode.py
+++ b/vimode.py
@@ -1046,20 +1046,17 @@ for i in range(10, 99):
     VI_KEYS['\x01[j%s' % i] = "/buffer %s" % i
 
 class UserMapping:
-    """Wraps User Mapping
-
-    Enables multiple actions to be defined by a single mapping.
-    """
-    def __init__(self, keys, cmd):
+    """Wraps User Mapping Defined by :nmap Command"""
+    def __init__(self, keys, full_cmd):
         self.keys = keys
-        self.cmd = cmd
+        self.full_cmd = full_cmd
         self.count = 0
         self.bad_sequence = ""
 
     def __call__(self, buf, input_line, cur, count):
         for _ in range(max(count, 1)):
             bad_sequence_list = []
-            for action in self.get_cmd_actions(self.cmd, first_call=True):
+            for action in self.get_cmd_actions(self.full_cmd, first_call=True):
                 debug_print('action', action)
                 debug_print('buf', buf)
                 debug_print('input_line', input_line)
@@ -1085,7 +1082,7 @@ class UserMapping:
             for bad_seq in bad_sequence_list:
                 error_msg = 'Failed to parse "{}" sequence ' \
                     'in the following user mapping: ' \
-                    '({}, {}).'.format(bad_seq, self.keys, self.cmd)
+                    '({}, {}).'.format(bad_seq, self.keys, self.full_cmd)
                 print_warning(error_msg)
 
     def get_cmd_actions(self, cmd, *, first_call=False):

--- a/vimode.py
+++ b/vimode.py
@@ -255,6 +255,12 @@ def cmd_nunmap(args):
         mappings = vimode_settings['user_mappings']
         if key in mappings:
             del mappings[key]
+            del VI_KEYS[key]
+
+            # restore default keys
+            if key in VI_DEFAULT_KEYS:
+                VI_KEYS[key] = VI_DEFAULT_KEYS[key]
+
             weechat.config_set_plugin('user_mappings', json.dumps(mappings))
             vimode_settings['user_mappings'] = mappings
         else:
@@ -993,75 +999,79 @@ def key_ctrl_r(buf, input_line, cur, count):
 
 # String values will be executed as normal WeeChat commands.
 # For functions, see `key_base()` for reference.
-VI_KEYS = {'j': "/window scroll_down",
-           'k': "/window scroll_up",
-           'G': key_G,
-           'gg': "/window scroll_top",
-           'x': "/input delete_next_char",
-           'X': "/input delete_previous_char",
-           'dd': "/input delete_line",
-           'D': "/input delete_end_of_line",
-           'cc': key_cc,
-           'C': key_C,
-           'i': key_i,
-           'a': key_a,
-           'A': key_A,
-           'I': key_I,
-           'yy': key_yy,
-           'p': key_p,
-           'gt': "/buffer -1",
-           'K': "/buffer -1",
-           'gT': "/buffer +1",
-           'J': "/buffer +1",
-           'r': key_r,
-           'R': key_R,
-           '~': key_tilda,
-           'nt': "/bar scroll nicklist * -100%",
-           'nT': "/bar scroll nicklist * +100%",
-           '\x01[[A': "/input history_previous",
-           '\x01[[B': "/input history_next",
-           '\x01[[C': "/input move_next_char",
-           '\x01[[D': "/input move_previous_char",
-           '\x01[[H': "/input move_beginning_of_line",
-           '\x01[[F': "/input move_end_of_line",
-           '\x01[[5~': "/window page_up",
-           '\x01[[6~': "/window page_down",
-           '\x01[[3~': "/input delete_next_char",
-           '\x01[[2~': key_i,
-           '\x01M': "/input return",
-           '\x01?': "/input move_previous_char",
-           ' ': "/input move_next_char",
-           '\x01[j': key_alt_j,
-           '\x01[1': "/buffer *1",
-           '\x01[2': "/buffer *2",
-           '\x01[3': "/buffer *3",
-           '\x01[4': "/buffer *4",
-           '\x01[5': "/buffer *5",
-           '\x01[6': "/buffer *6",
-           '\x01[7': "/buffer *7",
-           '\x01[8': "/buffer *8",
-           '\x01[9': "/buffer *9",
-           '\x01[0': "/buffer *10",
-           '\x01^': "/input jump_last_buffer_displayed",
-           '\x01D': "/window page_down",
-           '\x01U': "/window page_up",
-           '\x01Wh': "/window left",
-           '\x01Wj': "/window down",
-           '\x01Wk': "/window up",
-           '\x01Wl': "/window right",
-           '\x01W=': "/window balance",
-           '\x01Wx': "/window swap",
-           '\x01Ws': "/window splith",
-           '\x01Wv': "/window splitv",
-           '\x01Wq': "/window merge",
-           ';': key_semicolon,
-           ',': key_comma,
-           'u': key_u,
-           '\x01R': key_ctrl_r}
+VI_DEFAULT_KEYS = {'j': "/window scroll_down",
+                   'k': "/window scroll_up",
+                   'G': key_G,
+                   'gg': "/window scroll_top",
+                   'x': "/input delete_next_char",
+                   'X': "/input delete_previous_char",
+                   'dd': "/input delete_line",
+                   'D': "/input delete_end_of_line",
+                   'cc': key_cc,
+                   'C': key_C,
+                   'i': key_i,
+                   'a': key_a,
+                   'A': key_A,
+                   'I': key_I,
+                   'yy': key_yy,
+                   'p': key_p,
+                   'gt': "/buffer -1",
+                   'K': "/buffer -1",
+                   'gT': "/buffer +1",
+                   'J': "/buffer +1",
+                   'r': key_r,
+                   'R': key_R,
+                   '~': key_tilda,
+                   'nt': "/bar scroll nicklist * -100%",
+                   'nT': "/bar scroll nicklist * +100%",
+                   '\x01[[A': "/input history_previous",
+                   '\x01[[B': "/input history_next",
+                   '\x01[[C': "/input move_next_char",
+                   '\x01[[D': "/input move_previous_char",
+                   '\x01[[H': "/input move_beginning_of_line",
+                   '\x01[[F': "/input move_end_of_line",
+                   '\x01[[5~': "/window page_up",
+                   '\x01[[6~': "/window page_down",
+                   '\x01[[3~': "/input delete_next_char",
+                   '\x01[[2~': key_i,
+                   '\x01M': "/input return",
+                   '\x01?': "/input move_previous_char",
+                   ' ': "/input move_next_char",
+                   '\x01[j': key_alt_j,
+                   '\x01[1': "/buffer *1",
+                   '\x01[2': "/buffer *2",
+                   '\x01[3': "/buffer *3",
+                   '\x01[4': "/buffer *4",
+                   '\x01[5': "/buffer *5",
+                   '\x01[6': "/buffer *6",
+                   '\x01[7': "/buffer *7",
+                   '\x01[8': "/buffer *8",
+                   '\x01[9': "/buffer *9",
+                   '\x01[0': "/buffer *10",
+                   '\x01^': "/input jump_last_buffer_displayed",
+                   '\x01D': "/window page_down",
+                   '\x01U': "/window page_up",
+                   '\x01Wh': "/window left",
+                   '\x01Wj': "/window down",
+                   '\x01Wk': "/window up",
+                   '\x01Wl': "/window right",
+                   '\x01W=': "/window balance",
+                   '\x01Wx': "/window swap",
+                   '\x01Ws': "/window splith",
+                   '\x01Wv': "/window splitv",
+                   '\x01Wq': "/window merge",
+                   ';': key_semicolon,
+                   ',': key_comma,
+                   'u': key_u,
+                   '\x01R': key_ctrl_r}
 
 # Add alt-j<number> bindings.
 for i in range(10, 99):
-    VI_KEYS['\x01[j%s' % i] = "/buffer %s" % i
+    VI_DEFAULT_KEYS['\x01[j%s' % i] = "/buffer %s" % i
+
+# VI_DEFAULT_KEYS are kept in a separate data structure to ensure
+# that they can not be permenantly deleted by the `:nunmap` command.
+VI_KEYS = VI_DEFAULT_KEYS.copy()
 
 class UMParser(metaclass=ABCMeta):
     """User Mapping Parser


### PR DESCRIPTION
New behavior is more consistent with how vim-bindings work. There are
several benefits to this new implementation:

1) Commands can more easily be bound together:
     - INPUT: `:nmap h /cmd1<CR>/cmd2<CR>`
     - OUTPUT [h]: Runs /cmd1 then /cmd2.

2) User defined bindings can now be followed:
     - INPUT: `:nmap j 3Jh`
     - OUTPUT [j]: Travel three buffers down, then runs /cmd1, then runs /cmd2.

3) Bindings can take advantage of INSERT mode:
     - INPUT: `:nmap k i MESSAGE<Esc>0i`
     - OUTPUT [k]: Prints ' MESSAGE' to command-line and then returns the user to the beginning of the line. The user is left in INSERT mode.

Note that the old behavior is still supported (e.g. `:nmap /command [options]` without a trailing `<CR>`).