### PR TITLE
added bar_new compatibility with weechat version >=2.9

### DIFF
--- a/vimode.py
+++ b/vimode.py
@@ -2208,9 +2208,18 @@ if __name__ == "__main__":
     weechat.bar_item_new("cmd_completion", "cb_cmd_completion", "")
     weechat.bar_item_new("vi_buffer", "cb_vi_buffer", "")
     weechat.bar_item_new("line_numbers", "cb_line_numbers", "")
-    weechat.bar_new("vi_line_numbers", "on", "0", "window", "", "left",
-                    "vertical", "vertical", "0", "0", "default", "default",
-                    "default", "0", "line_numbers")
+
+    # make compatible with updated `bar_new`(>=2.9)
+    version = int(weechat.info_get('version_number', '')) or 0
+    if version >= 0x02090000:
+        weechat.bar_new("vi_line_numbers", "on", "0", "window", "", "left",
+                        "vertical", "vertical", "0", "0", "default", "default",
+                        "default", "default", "0", "line_numbers")
+    else:
+        weechat.bar_new("vi_line_numbers", "on", "0", "window", "", "left",
+                        "vertical", "vertical", "0", "0", "default", "default",
+                        "default", "0", "line_numbers")
+
     weechat.hook_config("plugins.var.python.%s.*" % SCRIPT_NAME, "cb_config",
                         "")
     weechat.hook_signal("key_pressed", "cb_key_pressed", "")


### PR DESCRIPTION
https://weechat.org/files/releasenotes/ReleaseNotes-devel.html#v2.9_bar_color_bg_inactive

Used the fix, as they use in the other plugins